### PR TITLE
Added ability to write custom script for Selectbox

### DIFF
--- a/src/Components/Form/SelectBox.php
+++ b/src/Components/Form/SelectBox.php
@@ -33,6 +33,11 @@ class SelectBox extends FormElementInterface
     public $search = false;
 
     /**
+     * $var string
+     */
+    public $script = "{}";
+
+    /**
      * SelectBox constructor.
      *
      * @param array $properties

--- a/src/Components/Form/SelectBox.php
+++ b/src/Components/Form/SelectBox.php
@@ -28,11 +28,6 @@ class SelectBox extends FormElementInterface
     public $data = [];
 
     /**
-     * @var bool
-     */
-    public $search = false;
-
-    /**
      * $var string
      */
     public $script = "{}";

--- a/src/Components/Form/SelectBox.php
+++ b/src/Components/Form/SelectBox.php
@@ -28,11 +28,6 @@ class SelectBox extends FormElementInterface
     public $data = [];
 
     /**
-     * $var string
-     */
-    public $script = "{}";
-
-    /**
      * SelectBox constructor.
      *
      * @param array $properties

--- a/src/Components/Page/FormPage.php
+++ b/src/Components/Page/FormPage.php
@@ -59,6 +59,11 @@ class FormPage implements PageInterface
     public $basicAlerts = [];
 
     /**
+     * @var array
+     */
+    public $script = [];
+
+    /**
      * @var string
      */
     private $view = 'pages/form';
@@ -110,6 +115,27 @@ class FormPage implements PageInterface
     {
 
         $this->form[] = $item;
+
+    }
+
+
+    /**
+     * @param $item
+     */
+    public function addScript($item)
+    {
+
+        $this->script[] = $item;
+
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getScript()
+    {
+
+        return $this->script;
 
     }
 

--- a/src/views/starlight/admin-layout.blade.php
+++ b/src/views/starlight/admin-layout.blade.php
@@ -85,5 +85,8 @@
         minimumResultsForSearch: ''
     });
 </script>
+
+@yield('customScripts')
+
 </body>
 </html>

--- a/src/views/starlight/admin-layout.blade.php
+++ b/src/views/starlight/admin-layout.blade.php
@@ -77,15 +77,6 @@
 <script src="/assets/admin/js/ResizeSensor.js"></script>
 <script src="/assets/admin/lib/select2/js/select2.min.js"></script>
 
-<script>
-    $('.select2').select2({
-        minimumResultsForSearch: Infinity
-    });
-    $('.select2-show-search').select2({
-        minimumResultsForSearch: ''
-    });
-</script>
-
 @yield('customScripts')
 
 </body>

--- a/src/views/starlight/form-elements/select-box.blade.php
+++ b/src/views/starlight/form-elements/select-box.blade.php
@@ -1,13 +1,9 @@
 <div class="row sadmin-input">
     <label class="col-lg-3 col-md-4 form-control-label">{{ $row->label }}:</label>
     <div class="col-lg-9 col-md-8 mg-t-10 mg-sm-t-0">
-        @php
-            $typeClass = $row->script ? '-'.rand ( 100000000 , 999999999 ) : '';
-        @endphp
         <select
-                id="{{ $row->id ? $row->id : uniqid() }}"
-                class="form-control select2{{ $row->search && !$row->script ? '-show-search' : $typeClass }}
-                @if(is_array($row->class)){{ implode(' ',$row->class) }} @elseif(is_string($row->class)) {{ $row->class }} @endif
+                id="{{ $row->id }}"
+                class="form-control @if(is_array($row->class)){{ implode(' ',$row->class) }} @elseif(is_string($row->class)) {{ $row->class }} @endif
                 {{ $errors->get($row->name) ? ' is-invalid' : '' }}"
                 data-placeholder="{{ $row->placeholder }}"
                 @if($row->required)required @endif>
@@ -34,14 +30,6 @@
                 {{  $row->description }}
             </small>
 
-        @endif
-
-        @if($row->script)
-            @section('customScripts')
-                <script>
-                    $('.select2{{ $typeClass }}').select2({!! $row->script !!});
-                </script>
-            @endsection
         @endif
 
     </div>

--- a/src/views/starlight/form-elements/select-box.blade.php
+++ b/src/views/starlight/form-elements/select-box.blade.php
@@ -1,9 +1,12 @@
 <div class="row sadmin-input">
     <label class="col-lg-3 col-md-4 form-control-label">{{ $row->label }}:</label>
     <div class="col-lg-9 col-md-8 mg-t-10 mg-sm-t-0">
+        @php
+            $typeClass = $row->script ? '-'.rand ( 100000000 , 999999999 ) : '';
+        @endphp
         <select
                 id="{{ $row->id ? $row->id : uniqid() }}"
-                class="form-control {{ $row->search ? 'select2-show-search' : 'select2' }}
+                class="form-control select2{{ $row->search && !$row->script ? '-show-search' : $typeClass }}
                 @if(is_array($row->class)){{ implode(' ',$row->class) }} @elseif(is_string($row->class)) {{ $row->class }} @endif
                 {{ $errors->get($row->name) ? ' is-invalid' : '' }}"
                 data-placeholder="{{ $row->placeholder }}"
@@ -31,6 +34,14 @@
                 {{  $row->description }}
             </small>
 
+        @endif
+
+        @if($row->script)
+            @section('customScripts')
+                <script>
+                    $('.select2{{ $typeClass }}').select2({!! $row->script !!});
+                </script>
+            @endsection
         @endif
 
     </div>

--- a/src/views/starlight/pages/form.blade.php
+++ b/src/views/starlight/pages/form.blade.php
@@ -45,4 +45,13 @@
             </div>
         </div>
     </div>
+
+@endsection
+
+@section('customScripts')
+    @foreach($page->getScript() as $script)
+        <script>
+            {!! $script !!}
+        </script>
+    @endforeach
 @endsection


### PR DESCRIPTION
Example:
```
        $page->addFormItem(
            new SelectBox([
                'id' => 'select2-model',
                'label'       => 'Model',
                'name'        => 'modelId',
                'placeholder' => 'Please select model',
                'required'    => true,
            ])
        );

        $page->addScript(View::make('scripts.select2AjaxScript',[
            'id' => 'select2-model',
            'url' => route('modelsJson'),
            'take' => 20,
            'resultLabelPath' => 'name',
            'resultValuePath' => 'id'
        ]));

```

select2AjaxScript.blade.php

```

$('#{{$id}}').select2({
    ajax: {
        delay:750,
        url: "{{ $url }}",
        data: function (params) {
            return {
                search: params.term,
                page: params.page || 1,
                take: {{ isset($take) ? $take : 20 }}
            };
        },
        processResults: function (data) {
          return {
            results: $.map(data.results, function (item) {
                    return {
                        text: item.{!! $resultLabelPath !!},
                        id: item.{!! $resultValuePath !!}
                    }
                }),
            pagination: data.pagination
          };
        }
      }
});

```